### PR TITLE
[feat] AppWindow.close()

### DIFF
--- a/modules/astrodon-tauri/src/deno_runtime/runtime.rs
+++ b/modules/astrodon-tauri/src/deno_runtime/runtime.rs
@@ -1,7 +1,6 @@
 use crate::events_manager::EventsManager;
 use crate::AstrodonMessage;
 use crate::Metadata;
-use deno_core::anyhow::Error;
 use deno_core::error::AnyError;
 use deno_core::located_script_name;
 use deno_core::v8_set_flags;

--- a/modules/astrodon-tauri/src/messages.rs
+++ b/modules/astrodon-tauri/src/messages.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 pub enum AstrodonMessage {
     SentToWindow(SentToWindowMessage),
     RunWindow(RunWindowMessage),
+    CloseWindow(CloseWindowMessage),
     SentToDeno(String, String),
 }
 
@@ -11,6 +12,7 @@ pub enum AstrodonMessage {
 pub enum WryEvent {
     RunScript(String, String),
     NewWindow(RunWindowMessage),
+    CloseWindow(CloseWindowMessage),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -25,6 +27,11 @@ pub struct RunWindowMessage {
     pub id: String,
     pub title: String,
     pub content: WindowContent,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CloseWindowMessage {
+    pub id: String
 }
 
 #[derive(Serialize, Deserialize)]

--- a/modules/astrodon-tauri/src/wry_runtime.rs
+++ b/modules/astrodon-tauri/src/wry_runtime.rs
@@ -51,6 +51,11 @@ impl WryRuntime {
                             .send_event(WryEvent::NewWindow(msg))
                             .expect("Could not open a new window");
                     }
+                    AstrodonMessage::CloseWindow(msg) => {
+                        proxy
+                            .send_event(WryEvent::CloseWindow(msg))
+                            .expect("Could not close the window");
+                    }
                     AstrodonMessage::SentToDeno(name, content) => self
                         .events_manager
                         .send(name, content.clone())
@@ -103,6 +108,13 @@ impl WryRuntime {
                     ));
                     custom_id_mapper.insert(msg.id, new_window.0);
                     webviews.insert(new_window.0, new_window.1);
+                }
+                Event::UserEvent(WryEvent::CloseWindow(msg)) => {
+                    let id = custom_id_mapper.get(&msg.id);
+                    if let Some(window_id) = id {
+                        webviews.remove(&window_id);
+                        custom_id_mapper.remove(&msg.id);
+                    }
                 }
                 _ => (),
             }

--- a/modules/astrodon/window.ts
+++ b/modules/astrodon/window.ts
@@ -45,4 +45,10 @@ export class AppWindow {
       yield await (Deno as any).core.opAsync("listenEvent", { name });
     }
   };
+
+  close(){
+    return (Deno as any).core.opAsync("closeWindow", {
+      id: this.id,
+    });
+  }
 }


### PR DESCRIPTION
This adds the close method to AppWindow:

```ts
const window = new AppWindow("My app");

...

await window.close();

```